### PR TITLE
Download dart to a temp file and move it atomically to the target location

### DIFF
--- a/src/main/java/us/hebi/sass/PlatformUtil.java
+++ b/src/main/java/us/hebi/sass/PlatformUtil.java
@@ -20,6 +20,7 @@
 
 package us.hebi.sass;
 
+import org.apache.commons.io.FileUtils;
 import org.codehaus.plexus.archiver.AbstractUnArchiver;
 import org.codehaus.plexus.archiver.tar.TarGZipUnArchiver;
 import org.codehaus.plexus.archiver.tar.TarUnArchiver.UntarCompressionMethod;
@@ -39,6 +40,7 @@ import java.util.Locale;
  */
 public class PlatformUtil {
 
+    public static int BUFFER_SIZE = 1024;
     public static String getDefaultArchiveExtension() {
         return isWindows() ? "zip" : "tar.gz";
     }
@@ -52,7 +54,9 @@ public class PlatformUtil {
         Path tmpArchive = destinationDirectory.resolve(createTemporaryArchiveName(url.toExternalForm()));
         try (InputStream downloadFile = url.openStream()) {
             Files.createDirectories(destinationDirectory);
-            Files.copy(downloadFile, tmpArchive, StandardCopyOption.REPLACE_EXISTING);
+            Path tmpDownloadFile = Files.createTempFile(destinationDirectory, null, null);
+            FileUtils.copyInputStreamToFile(downloadFile, tmpDownloadFile.toFile());
+            Files.move(tmpDownloadFile, tmpArchive, StandardCopyOption.ATOMIC_MOVE);
         }
 
         // Extract

--- a/src/main/java/us/hebi/sass/PlatformUtil.java
+++ b/src/main/java/us/hebi/sass/PlatformUtil.java
@@ -39,117 +39,111 @@ import java.util.Locale;
  */
 public class PlatformUtil {
 
-  public static String getDefaultArchiveExtension() {
-    return isWindows() ? "zip" : "tar.gz";
-  }
-
-  public static String toScriptName(String name) {
-    return isWindows() ? name + ".bat" : name;
-  }
-
-  public static void downloadAndExtractArchive(URL url, Path destinationDirectory) throws IOException {
-    // Download
-    Path tmpDownloadFile;
-    try (InputStream downloadFile = url.openStream()) {
-      Files.createDirectories(destinationDirectory);
-      tmpDownloadFile = Files.createTempFile(destinationDirectory, null, createTemporaryArchiveSuffix(url.toExternalForm()));
-      FileUtils.copyInputStreamToFile(downloadFile, tmpDownloadFile.toFile());
+    public static String getDefaultArchiveExtension() {
+        return isWindows() ? "zip" : "tar.gz";
     }
 
-    // Extract
-    extractArchive(tmpDownloadFile, destinationDirectory);
-
-    // Cleanup
-    Files.delete(tmpDownloadFile);
-  }
-
-  private static String createTemporaryArchiveSuffix(String url) {
-    if (url.endsWith(".zip")) {
-      return ".zip";
-    } else if (url.endsWith(".tar.gz")) {
-      return ".tar.gz";
-    } else {
-      throw new UnsupportedOperationException("Unsupported archive extension on: " + url);
-    }
-  }
-
-  public static void extractArchive(Path sourceArchive, Path destinationDirectory) {
-    // Create appropriate unarchiver
-    final AbstractUnArchiver unArchiver;
-    String path = sourceArchive.toString().toLowerCase(Locale.ENGLISH);
-    if (path.endsWith(".zip")) {
-      unArchiver = new ZipUnArchiver();
-    } else if (path.endsWith(".tar.gz")) {
-      TarGZipUnArchiver untar = new TarGZipUnArchiver();
-      untar.setCompression(UntarCompressionMethod.GZIP);
-      unArchiver = untar;
-    } else {
-      throw new UnsupportedOperationException("Unsupported archive extension on: " + path);
+    public static String toScriptName(String name) {
+        return isWindows() ? name + ".bat" : name;
     }
 
-    // Extract to specified directory
-    unArchiver.setSourceFile(sourceArchive.toFile());
-    unArchiver.setOverwrite(true);
-    unArchiver.setDestDirectory(destinationDirectory.toFile());
-    unArchiver.extract();
-  }
+    public static void downloadAndExtractArchive(URL url, Path destinationDirectory) throws IOException {
+        // Download
+        Path tmpDownloadFile;
+        try (InputStream downloadFile = url.openStream()) {
+            Files.createDirectories(destinationDirectory);
+            tmpDownloadFile = Files.createTempFile(destinationDirectory, null, createTemporaryArchiveSuffix(url.toExternalForm()));
+            FileUtils.copyInputStreamToFile(downloadFile, tmpDownloadFile.toFile());
+        }
 
-  public enum Architecture {
-    x86_32, x86_64, arm_32, arm_64
-  }
+        // Extract
+        extractArchive(tmpDownloadFile, destinationDirectory);
 
-  public static Architecture getArch() {
-    // https://stackoverflow.com/a/36926327/3574093
-    switch (OS_ARCH) {
-      case "aarch64":
-        return Architecture.arm_64;
-      case "arm":
-        return Architecture.arm_32;
-      case "amd64":
-      case "ia64":
-      case "x86_64":
-        return Architecture.x86_64;
-      case "x86":
-      case "i386":
-      case "i486":
-      case "i586":
-      case "i686":
-        return Architecture.x86_32;
-      default:
-        throw new UnsupportedOperationException("Unsupported arch: " + System.getProperty("os.arch"));
+        // Cleanup
+        Files.delete(tmpDownloadFile);
     }
-  }
 
-  public enum OsFamily {
-    Windows, Linux, macOS;
-  }
-
-  public static OsFamily getOsFamily() {
-    if (isWindows()) {
-      return OsFamily.Windows;
+    private static String createTemporaryArchiveSuffix(String url) {
+        if (url.endsWith(".zip")) {
+            return ".zip";
+        } else if (url.endsWith(".tar.gz")) {
+            return ".tar.gz";
+        } else {
+            throw new UnsupportedOperationException("Unsupported archive extension on: " + url);
+        }
     }
-    if (isLinux()) {
-      return OsFamily.Linux;
+
+    public static void extractArchive(Path sourceArchive, Path destinationDirectory) {
+        // Create appropriate unarchiver
+        final AbstractUnArchiver unArchiver;
+        String path = sourceArchive.toString().toLowerCase(Locale.ENGLISH);
+        if (path.endsWith(".zip")) {
+            unArchiver = new ZipUnArchiver();
+        } else if (path.endsWith(".tar.gz")) {
+            TarGZipUnArchiver untar = new TarGZipUnArchiver();
+            untar.setCompression(UntarCompressionMethod.GZIP);
+            unArchiver = untar;
+        } else {
+            throw new UnsupportedOperationException("Unsupported archive extension on: " + path);
+        }
+
+        // Extract to specified directory
+        unArchiver.setSourceFile(sourceArchive.toFile());
+        unArchiver.setOverwrite(true);
+        unArchiver.setDestDirectory(destinationDirectory.toFile());
+        unArchiver.extract();
     }
-    if (isMac()) {
-      return OsFamily.macOS;
+
+    public enum Architecture {
+        x86_32, x86_64, arm_32, arm_64
     }
-    throw new UnsupportedOperationException("Unsupported OS: " + System.getProperty("os.name"));
-  }
 
-  public static boolean isWindows() {
-    return OS_NAME.startsWith("win");
-  }
+    public static Architecture getArch() {
+        // https://stackoverflow.com/a/36926327/3574093
+        switch (OS_ARCH) {
+            case "aarch64":
+                return Architecture.arm_64;
+            case "arm":
+                return Architecture.arm_32;
+            case "amd64":
+            case "ia64":
+            case "x86_64":
+                return Architecture.x86_64;
+            case "x86":
+            case "i386":
+            case "i486":
+            case "i586":
+            case "i686":
+                return Architecture.x86_32;
+            default:
+                throw new UnsupportedOperationException("Unsupported arch: " + System.getProperty("os.arch"));
+        }
+    }
 
-  public static boolean isMac() {
-    return OS_NAME.contains("mac");
-  }
+    public enum OsFamily {
+        Windows, Linux, macOS;
+    }
 
-  public static boolean isLinux() {
-    return OS_NAME.startsWith("linux");
-  }
+    public static OsFamily getOsFamily() {
+        if (isWindows()) return OsFamily.Windows;
+        if (isLinux()) return OsFamily.Linux;
+        if (isMac()) return OsFamily.macOS;
+        throw new UnsupportedOperationException("Unsupported OS: " + System.getProperty("os.name"));
+    }
 
-  public static final String OS_NAME = System.getProperty("os.name").toLowerCase(Locale.US);
-  public static final String OS_ARCH = System.getProperty("os.arch").toLowerCase(Locale.US);
+    public static boolean isWindows() {
+        return OS_NAME.startsWith("win");
+    }
+
+    public static boolean isMac() {
+        return OS_NAME.contains("mac");
+    }
+
+    public static boolean isLinux() {
+        return OS_NAME.startsWith("linux");
+    }
+
+    public static final String OS_NAME = System.getProperty("os.name").toLowerCase(Locale.US);
+    public static final String OS_ARCH = System.getProperty("os.arch").toLowerCase(Locale.US);
 
 }

--- a/src/main/java/us/hebi/sass/PlatformUtil.java
+++ b/src/main/java/us/hebi/sass/PlatformUtil.java
@@ -40,113 +40,121 @@ import java.util.Locale;
  */
 public class PlatformUtil {
 
-    public static int BUFFER_SIZE = 1024;
-    public static String getDefaultArchiveExtension() {
-        return isWindows() ? "zip" : "tar.gz";
+  public static String getDefaultArchiveExtension() {
+    return isWindows() ? "zip" : "tar.gz";
+  }
+
+  public static String toScriptName(String name) {
+    return isWindows() ? name + ".bat" : name;
+  }
+
+  public static void downloadAndExtractArchive(URL url, Path destinationDirectory) throws IOException {
+    // Download
+    Path tmpArchive = destinationDirectory.resolve(createTemporaryArchiveName(url.toExternalForm()));
+    try (InputStream downloadFile = url.openStream()) {
+      Files.createDirectories(destinationDirectory);
+      Path tmpDownloadFile = Files.createTempFile(destinationDirectory, null, null);
+      FileUtils.copyInputStreamToFile(downloadFile, tmpDownloadFile.toFile());
+      if (tmpArchive.toFile().exists()) {
+        tmpArchive.toFile().delete();
+      }
+      Files.move(tmpDownloadFile, tmpArchive, StandardCopyOption.ATOMIC_MOVE);
     }
 
-    public static String toScriptName(String name) {
-        return isWindows() ? name + ".bat" : name;
+    // Extract
+    extractArchive(tmpArchive, destinationDirectory);
+
+    // Cleanup
+    Files.delete(tmpArchive);
+  }
+
+  private static String createTemporaryArchiveName(String url) {
+    if (url.endsWith(".zip")) {
+      return "archive.zip";
+    } else if (url.endsWith(".tar.gz")) {
+      return "archive.tar.gz";
+    } else {
+      throw new UnsupportedOperationException("Unsupported archive extension on: " + url);
+    }
+  }
+
+  public static void extractArchive(Path sourceArchive, Path destinationDirectory) {
+    // Create appropriate unarchiver
+    final AbstractUnArchiver unArchiver;
+    String path = sourceArchive.toString().toLowerCase(Locale.ENGLISH);
+    if (path.endsWith(".zip")) {
+      unArchiver = new ZipUnArchiver();
+    } else if (path.endsWith(".tar.gz")) {
+      TarGZipUnArchiver untar = new TarGZipUnArchiver();
+      untar.setCompression(UntarCompressionMethod.GZIP);
+      unArchiver = untar;
+    } else {
+      throw new UnsupportedOperationException("Unsupported archive extension on: " + path);
     }
 
-    public static void downloadAndExtractArchive(URL url, Path destinationDirectory) throws IOException {
-        // Download
-        Path tmpArchive = destinationDirectory.resolve(createTemporaryArchiveName(url.toExternalForm()));
-        try (InputStream downloadFile = url.openStream()) {
-            Files.createDirectories(destinationDirectory);
-            Path tmpDownloadFile = Files.createTempFile(destinationDirectory, null, null);
-            FileUtils.copyInputStreamToFile(downloadFile, tmpDownloadFile.toFile());
-            Files.move(tmpDownloadFile, tmpArchive, StandardCopyOption.ATOMIC_MOVE);
-        }
+    // Extract to specified directory
+    unArchiver.setSourceFile(sourceArchive.toFile());
+    unArchiver.setOverwrite(true);
+    unArchiver.setDestDirectory(destinationDirectory.toFile());
+    unArchiver.extract();
+  }
 
-        // Extract
-        extractArchive(tmpArchive, destinationDirectory);
+  public enum Architecture {
+    x86_32, x86_64, arm_32, arm_64
+  }
 
-        // Cleanup
-        Files.delete(tmpArchive);
+  public static Architecture getArch() {
+    // https://stackoverflow.com/a/36926327/3574093
+    switch (OS_ARCH) {
+      case "aarch64":
+        return Architecture.arm_64;
+      case "arm":
+        return Architecture.arm_32;
+      case "amd64":
+      case "ia64":
+      case "x86_64":
+        return Architecture.x86_64;
+      case "x86":
+      case "i386":
+      case "i486":
+      case "i586":
+      case "i686":
+        return Architecture.x86_32;
+      default:
+        throw new UnsupportedOperationException("Unsupported arch: " + System.getProperty("os.arch"));
     }
+  }
 
-    private static String createTemporaryArchiveName(String url) {
-        if (url.endsWith(".zip")) {
-            return "archive.zip";
-        } else if (url.endsWith(".tar.gz")) {
-            return "archive.tar.gz";
-        } else {
-            throw new UnsupportedOperationException("Unsupported archive extension on: " + url);
-        }
+  public enum OsFamily {
+    Windows, Linux, macOS;
+  }
+
+  public static OsFamily getOsFamily() {
+    if (isWindows()) {
+      return OsFamily.Windows;
     }
-
-    public static void extractArchive(Path sourceArchive, Path destinationDirectory) {
-        // Create appropriate unarchiver
-        final AbstractUnArchiver unArchiver;
-        String path = sourceArchive.toString().toLowerCase(Locale.ENGLISH);
-        if (path.endsWith(".zip")) {
-            unArchiver = new ZipUnArchiver();
-        } else if (path.endsWith(".tar.gz")) {
-            TarGZipUnArchiver untar = new TarGZipUnArchiver();
-            untar.setCompression(UntarCompressionMethod.GZIP);
-            unArchiver = untar;
-        } else {
-            throw new UnsupportedOperationException("Unsupported archive extension on: " + path);
-        }
-
-        // Extract to specified directory
-        unArchiver.setSourceFile(sourceArchive.toFile());
-        unArchiver.setOverwrite(true);
-        unArchiver.setDestDirectory(destinationDirectory.toFile());
-        unArchiver.extract();
+    if (isLinux()) {
+      return OsFamily.Linux;
     }
-
-    public enum Architecture {
-        x86_32, x86_64, arm_32, arm_64
+    if (isMac()) {
+      return OsFamily.macOS;
     }
+    throw new UnsupportedOperationException("Unsupported OS: " + System.getProperty("os.name"));
+  }
 
-    public static Architecture getArch() {
-        // https://stackoverflow.com/a/36926327/3574093
-        switch (OS_ARCH) {
-            case "aarch64":
-                return Architecture.arm_64;
-            case "arm":
-                return Architecture.arm_32;
-            case "amd64":
-            case "ia64":
-            case "x86_64":
-                return Architecture.x86_64;
-            case "x86":
-            case "i386":
-            case "i486":
-            case "i586":
-            case "i686":
-                return Architecture.x86_32;
-            default:
-                throw new UnsupportedOperationException("Unsupported arch: " + System.getProperty("os.arch"));
-        }
-    }
+  public static boolean isWindows() {
+    return OS_NAME.startsWith("win");
+  }
 
-    public enum OsFamily {
-        Windows, Linux, macOS;
-    }
+  public static boolean isMac() {
+    return OS_NAME.contains("mac");
+  }
 
-    public static OsFamily getOsFamily() {
-        if (isWindows()) return OsFamily.Windows;
-        if (isLinux()) return OsFamily.Linux;
-        if (isMac()) return OsFamily.macOS;
-        throw new UnsupportedOperationException("Unsupported OS: " + System.getProperty("os.name"));
-    }
+  public static boolean isLinux() {
+    return OS_NAME.startsWith("linux");
+  }
 
-    public static boolean isWindows() {
-        return OS_NAME.startsWith("win");
-    }
-
-    public static boolean isMac() {
-        return OS_NAME.contains("mac");
-    }
-
-    public static boolean isLinux() {
-        return OS_NAME.startsWith("linux");
-    }
-
-    public static final String OS_NAME = System.getProperty("os.name").toLowerCase(Locale.US);
-    public static final String OS_ARCH = System.getProperty("os.arch").toLowerCase(Locale.US);
+  public static final String OS_NAME = System.getProperty("os.name").toLowerCase(Locale.US);
+  public static final String OS_ARCH = System.getProperty("os.arch").toLowerCase(Locale.US);
 
 }

--- a/src/main/java/us/hebi/sass/PlatformUtil.java
+++ b/src/main/java/us/hebi/sass/PlatformUtil.java
@@ -31,7 +31,6 @@ import java.io.InputStream;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.StandardCopyOption;
 import java.util.Locale;
 
 /**
@@ -50,29 +49,25 @@ public class PlatformUtil {
 
   public static void downloadAndExtractArchive(URL url, Path destinationDirectory) throws IOException {
     // Download
-    Path tmpArchive = destinationDirectory.resolve(createTemporaryArchiveName(url.toExternalForm()));
+    Path tmpDownloadFile;
     try (InputStream downloadFile = url.openStream()) {
       Files.createDirectories(destinationDirectory);
-      Path tmpDownloadFile = Files.createTempFile(destinationDirectory, null, null);
+      tmpDownloadFile = Files.createTempFile(destinationDirectory, null, createTemporaryArchiveSuffix(url.toExternalForm()));
       FileUtils.copyInputStreamToFile(downloadFile, tmpDownloadFile.toFile());
-      if (tmpArchive.toFile().exists()) {
-        tmpArchive.toFile().delete();
-      }
-      Files.move(tmpDownloadFile, tmpArchive, StandardCopyOption.ATOMIC_MOVE);
     }
 
     // Extract
-    extractArchive(tmpArchive, destinationDirectory);
+    extractArchive(tmpDownloadFile, destinationDirectory);
 
     // Cleanup
-    Files.delete(tmpArchive);
+    Files.delete(tmpDownloadFile);
   }
 
-  private static String createTemporaryArchiveName(String url) {
+  private static String createTemporaryArchiveSuffix(String url) {
     if (url.endsWith(".zip")) {
-      return "archive.zip";
+      return ".zip";
     } else if (url.endsWith(".tar.gz")) {
-      return "archive.tar.gz";
+      return ".tar.gz";
     } else {
       throw new UnsupportedOperationException("Unsupported archive extension on: " + url);
     }


### PR DESCRIPTION
The copy operation fails occasionally with FileAlreadyExistsException. The problem seems to be caused by an IO lock that is held on target file.
`Caused by: java.nio.file.FileAlreadyExistsException: /home/circleci/.hebi/sass/dart-sass-1.59.3-linux-x64/archive.tar.gz at sun.nio.fs.UnixException.translateToIOException (UnixException.java:94) at sun.nio.fs.UnixException.rethrowAsIOException (UnixException.java:106) at sun.nio.fs.UnixException.rethrowAsIOException (UnixException.java:111) at sun.nio.fs.UnixFileSystemProvider.newByteChannel (UnixFileSystemProvider.java:218) at java.nio.file.spi.FileSystemProvider.newOutputStream (FileSystemProvider.java:484) at java.nio.file.Files.newOutputStream (Files.java:228) at java.nio.file.Files.copy (Files.java:3160) at us.hebi.sass.PlatformUtil.downloadAndExtractArchive (PlatformUtil.java:55)`

I've closed the initial PR and squashed commits